### PR TITLE
[Docs] Getting Started Section

### DIFF
--- a/packages/docs/src/components/ModalScene.tsx
+++ b/packages/docs/src/components/ModalScene.tsx
@@ -32,8 +32,13 @@ const StyledInput = styled.input`
 
 const StyledLabel = styled.label``;
 
-const ModalScene = ({ primary: primaryColor }) => {
-  const theme = genTheme({ themeColors: { primary: primaryColor } });
+const ModalScene = ({ primary: primaryColor, spacing: spacingUpdate }) => {
+  const spacingFourSetting = spacingUpdate ? `${spacingUpdate}px` : '24px';
+
+  const theme = genTheme({
+    themeColors: { primary: primaryColor },
+    spacing: { 4: spacingFourSetting }
+  });
   console.log('In ModalScene.tsx, this is genTheme: ', theme);
 
   return (

--- a/packages/docs/src/stories/theme/gettingStarted.stories.mdx
+++ b/packages/docs/src/stories/theme/gettingStarted.stories.mdx
@@ -105,11 +105,11 @@ theme: theme({ themeColors: { primary: '#6AD193' } })
   </Story>
 </Canvas>
 
-Updateable colors in Storybook Controls:
+Open the "Controllable Modal Scene" in Storybook Canvas to see how updating the `primary` color affects the scene:
 
 export const ControllableTemplate = args => {
-  const { primary } = args;
-  return <ModalScene primary={primary} />;
+  const { primary, spacing } = args;
+  return <ModalScene primary={primary} spacing={spacing} />;
 };
 
 <Canvas>
@@ -120,10 +120,16 @@ export const ControllableTemplate = args => {
         control: {
           type: 'color'
         }
+      },
+      spacing: {
+        control: {
+          type: 'range'
+        }
       }
     }}
     args={{
-      primary: '#000000'
+      primary: '#000000',
+      spacing: 24
     }}
   >
     {ControllableTemplate.bind({})}


### PR DESCRIPTION
This adds the start of a "Getting Started" documentation section.  This has a few very basic examples using the Refract `Button` component and has a placeholder modal scene with 2 controllable Storybook props, `primary` and `spacing`.

The modal example is only using the Refract `Button` component and the rest of the elements are just styled via the `GlobalStyles`.  Once other components get to a better state, I assume we can revisit the scene and add then in accordingly. 