### PR TITLE
fix(Decorator): use `SubTheme` for storybook decorator

### DIFF
--- a/packages/docs/src/preset/decorators/withRefract.tsx
+++ b/packages/docs/src/preset/decorators/withRefract.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { StoryContext } from '@storybook/addons';
-// import { ComponentStory, Story } from '@storybook/react';
-import { ThemeProvider } from 'styled-components';
-import { Theme, theme as genTheme } from '@refract-ui/core';
+import { Theme, SubTheme, theme as genTheme } from '@refract-ui/core';
 
 export type RefractDecoratorTheme = {
   theme: Theme;
@@ -24,8 +22,8 @@ export function withRefract(Story: any, c: StoryContext): any {
       : decoratorThemes[0];
 
   return (
-    <ThemeProvider theme={theme}>
+    <SubTheme theme={theme}>
       <Story {...c} />
-    </ThemeProvider>
+    </SubTheme>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,7 +3602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@refract-ui/core@workspace:*, @refract-ui/core@workspace:packages/core":
+"@refract-ui/core@0.1.28, @refract-ui/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@refract-ui/core@workspace:packages/core"
   dependencies:
@@ -3629,7 +3629,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@refract-ui/docs@workspace:packages/docs"
   dependencies:
-    "@refract-ui/core": "workspace:*"
+    "@refract-ui/core": 0.1.28
     "@types/faker": ^4.1.12
     babel-plugin-styled-components: 2.0.2
     faker: ^4.1.0


### PR DESCRIPTION
This PR fixes an issue where the where fonts were not rendering correctly in storybook. It was because we were using the generic `ThemeProvider` rather than the `SubTheme` provider, so we weren't getting the global styles we actually needed. This swaps in `SubTheme` for `ThemeProvider`